### PR TITLE
Liquefaction track: GLM digital-twin (Pillar 2 §3) + roadmap

### DIFF
--- a/DOCS_ROADMAP.md
+++ b/DOCS_ROADMAP.md
@@ -152,9 +152,13 @@ Inferred from current ModelHub/ESS attributions — confirm and adjust:
 
 ## 7. Liquefaction track roadmap (Pillar 2b)
 
-The liquefaction track ([Pillar 2 §3](book/chapters/pillar-2-nowcasting-susceptibility.md))
-builds a **ground liquefaction model (GLM) digital twin** on the Sanger/Maurer geospatial line
-of work. Lead: **Morgan Sanger, Brett Maurer** (with Yiyu Ni for the wavefield coupling).
+The liquefaction track builds a **ground liquefaction model (GLM) digital twin** on the
+Sanger/Maurer geospatial line of work, documented across three pages mirroring the landslide
+split: the science overview in
+[Pillar 2 §3](book/chapters/pillar-2-nowcasting-susceptibility.md), the model on
+[modelhub-liquefaction](book/chapters/modelhub-liquefaction.md), and the data on
+[datahub-liquefaction-inventory](book/chapters/datahub-liquefaction-inventory.md). Lead:
+**Morgan Sanger, Brett Maurer** (with Yiyu Ni for the wavefield coupling).
 
 ### 7.1 The three products to deliver
 1. **Conditional (national):** $P(\text{liq}\mid IM)$ from the national GLM surrogate

--- a/DOCS_ROADMAP.md
+++ b/DOCS_ROADMAP.md
@@ -149,3 +149,51 @@ Inferred from current ModelHub/ESS attributions — confirm and adjust:
 - **Convective storms / heatwaves:** Alexandra Anderson-Frey, Greg Hakim
 - **Floods:** _to assign_
 - **Evaluation & metrics:** _to assign_ (with Nathan Kutz / Kaggle / AI2)
+
+## 7. Liquefaction track roadmap (Pillar 2b)
+
+The liquefaction track ([Pillar 2 §3](book/chapters/pillar-2-nowcasting-susceptibility.md))
+builds a **ground liquefaction model (GLM) digital twin** on the Sanger/Maurer geospatial line
+of work. Lead: **Morgan Sanger, Brett Maurer** (with Yiyu Ni for the wavefield coupling).
+
+### 7.1 The three products to deliver
+1. **Conditional (national):** $P(\text{liq}\mid IM)$ from the national GLM surrogate
+   (`sanger2025jgge`). Needs high-resolution geospatial $V_{s30}$, water table, geology.
+2. **Unconditional (return period):** integrate the conditional model over the USGS NSHM hazard
+   curve for total liquefaction hazard at a return period. Needs NSHM disaggregation
+   (`gaia-nhsm-deagg`).
+3. **Event-based (scenario):** rupture → ShakeMap → GLM map (the real-time nowcast), e.g.
+   Cascadia / Nisqually.
+
+### 7.2 Data inventory needs (DataHub)
+- High-resolution **static** layers: $V_{s30}$ / $V_s$ profiles (`sanger2025vs`), surficial
+  geology, water-table depth — all spatially resolved (the resolution argument: even static
+  layers must be fine-scale).
+- **Dynamic** layers: water table from groundwater modeling (sea-level rise + seasonal), and
+  the seismic-derived $V_s(t)$ / $\kappa_0(t)$.
+- Ground motion: ShakeMap (event) and NSHM hazard curves (probabilistic).
+- Apply the **cross-hazard icon tagging** (Pillar 2 §3.6) to the whole DataHub inventory.
+
+### 7.3 Modeling needs (ModelHub)
+- The mechanics-informed GLM surrogate (conditional engine).
+- The unconditional integration over NSHM.
+- Groundwater-level model for the dynamic water table.
+- Earth2Studio integration for the dynamic forcing and scenario ensembles.
+
+### 7.4 Open research question — time-varying attenuation
+Whether and how to feed a **time-varying $\kappa_0(t)$ / $V_s(t)$** site term (which the GAIA
+seismic networks can estimate, and which varies seasonally — `haendel2025`, `ktenidou2015`)
+back into the NSHM-based unconditional hazard. Currently the NSHM uses a fixed reference-rock
+site term.
+
+### 7.5 Repositories
+Real: [`da-seis-groundfailure`](https://github.com/gaia-hazlab/da-seis-groundfailure),
+[`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg). Proposed placeholders for
+Morgan to confirm/create: `gaia-model-liquefaction`, `gaia-vs-conus`.
+
+### 7.6 Phasing
+- **L0 (now):** documentation scaffold + verified references (this branch).
+- **L1:** unconditional national susceptibility from the GLM surrogate + NSHM.
+- **L2:** couple groundwater modeling for dynamic / seasonal / sea-level-rise water table.
+- **L3:** event-based nowcast (ShakeMap → GLM) for a Cascadia/Nisqually scenario.
+- **L4:** time-varying attenuation research (§7.4); Earth2Studio scenario ensembles.

--- a/book/chapters/datahub-liquefaction-inventory.md
+++ b/book/chapters/datahub-liquefaction-inventory.md
@@ -1,0 +1,114 @@
+# Liquefaction Data Inventory
+
+:::{note}
+**The authoritative data inventory for the liquefaction digital twin.** This page catalogs
+every dataset that flows through the [liquefaction](hazard-liquefaction-ground-failure) digital
+twin — from **raw external products**, through **deterministically derived layers**, to **model
+outputs** — with sources, access/sensitivity, spatial/temporal resolution, and limitations.
+
+It is the liquefaction-specific companion to the [DataHub](datahub) and follows the four-part
+provenance standard (source · measurement · resolution · uncertainty) defined in the
+[DataHub Integration Guide §2](datahub-integration-guide). The model that consumes it is the
+[Liquefaction Model](modelhub-liquefaction); the science is in
+[Pillar 2 §3](pillar-2-nowcasting-susceptibility).
+:::
+
+## How to read this inventory
+
+Each layer is tagged with the **hazard purpose** it serves, so the DataHub inventory is shared
+and de-duplicated across hazards rather than rebuilt per hazard.
+
+**Legend:** ⛰️ landslides (shallow/deep) · 🔥 post-fire debris flows · 🏚️ liquefaction &
+ground failure · 🌊 floods
+
+Data are grouped by **provenance tier**, because that determines how they should be trusted,
+stored, and calibrated:
+
+1. **Raw / observed inputs** — imported from an external archive; held fixed in calibration.
+2. **Derived variables** — computed deterministically from raw inputs and documented rules.
+3. **Modelled variables & outputs** — produced by the GLM during a run; carry assumptions and
+   uncertainty.
+
+The **primary target** is the **probability / areal extent of liquefaction** $P(\text{liq})$ and
+its manifestation severity (LPI / LSN), in the three framings of
+[modelhub-liquefaction §4](modelhub-liquefaction).
+
+## 1. Raw / observed inputs (external products)
+
+| Layer / product | Source · archive | Access / sensitivity | Native res · CRS | Cadence | Units | Serves | Key limitations |
+|---|---|---|---|---|---|---|---|
+| **Shear-wave velocity** → $V_{s30}$, $V_s(z)$ | parametric CONUS $V_s$ [@sanger2025vs]; USGS National Crustal Model; proxy $V_{s30}$ from slope/geology | Public / open | parametric; proxy ~250–1000 m | Static (→ dynamic via seismic) | m s⁻¹ | 🏚️ ⛰️ | Proxy $V_{s30}$ has large scatter; profile uncertainty; **rigidity is high-influence** |
+| **Water-table depth** → $d_{wt}$ | [Pillar 1 Soil Reanalysis](pillar-1-soil-reanalysis); [groundwater modeling](groundwater-soil-moisture); modeled WTD (Zhu GLM) | Mixed | tens of m target; coarse priors | **Dynamic** (seasonal, sea-level) | m | 🏚️ ⛰️ 🌊 | Saturation is a **binary gate**; coarse priors smear hazard; the key dynamic control |
+| **Surficial geology / soil type** | state geologic surveys; USGS; SOLUS/POLARIS texture | Public / open | varies (1:24k–1:100k) | Static | categorical | 🏚️ ⛰️ | Map-scale generalization; susceptibility class boundaries uncertain |
+| **Ground motion (event)** → PGA, PGV, MMI | USGS ShakeMap ([earthquake.usgs.gov/data/shakemap](https://earthquake.usgs.gov/data/shakemap/)) | Public / open | event grid | Per-event | g, cm s⁻¹ | 🏚️ | ShakeMap & GMM epistemic uncertainty; the conditional/event **demand** input |
+| **Seismic hazard (probabilistic)** → hazard curves $\lambda(IM)$ | USGS NSHM [@petersen2024] via [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) | Public / open | site / gridded | Static (model epoch) | rate vs IM | 🏚️ | Fixed reference-rock site term (§5 open question); model-epoch dependence |
+| **Attenuation** → $\kappa_0$ | high-frequency spectral decay of recordings [@andersonhough1984]; GAIA seismic/DAS | Public / network | per site/station | Static (→ dynamic) | s | 🏚️ | Band/method-dependent; seasonal variability [@haendel2025] — not yet wired |
+| **Geotechnical case histories** (calibration) | CPT/SPT liquefaction databases (Christchurch, etc. [@vanballegooy2014]) | Public / curated | point | Event-based | varies | 🏚️ | Geographic bias; the surrogate's training/validation base |
+| **Precipitation / climate** (for groundwater) | PRISM / HRRR via [`gaia-cli`](https://github.com/gaia-hazlab/gaia-cli); Earth2Studio forecast | 4 km free; 800 m licensed | 4 km (→ forecast) | Daily / forecast | mm day⁻¹ | ⛰️ 🔥 🌊 🏚️ | Drives the **dynamic** water table; least-skillful forecast field |
+| **Observed liquefaction maps** → validation labels | post-earthquake reconnaissance (e.g. 2001 [Nisqually](wa-2001-2031-nisqually-earthquake)); GEER | Public / curated | vector | Per-event | presence / severity | 🏚️ | Mapping completeness & subjectivity; used only to **score**, never as input |
+
+## 2. Derived variables (deterministic transformations)
+
+| Derived variable | Computed from | Units | Rule | Why it matters |
+|---|---|---|---|---|
+| Total / effective stress $\sigma_{v0}$, $\sigma'_{v0}$ | overburden + water table $d_{wt}$ | kPa | $\sigma'_{v0}=\sigma_{v0}-u$ | Couples **hydrology** into CSR & CRR |
+| Stress-corrected velocity $V_{s1}$ | $V_s$, $\sigma'_{v0}$ | m s⁻¹ | $V_{s1}=V_s\,(P_a/\sigma'_{v0})^{0.25}$ | Overburden-normalized **rigidity** for CRR [@andrusstokoe2000] |
+| Cyclic stress ratio $\mathrm{CSR}$ | $a_{max}$, $\sigma_{v0}/\sigma'_{v0}$, $r_d$ | – | §2 of [model page](modelhub-liquefaction) | Seismic **demand** |
+| Magnitude / overburden corrections | $M$, $\sigma'_{v0}$ | – | MSF, $K_\sigma$ | Normalizes CSR to a reference |
+| Compound topographic index / distance-to-water | DEM; hydrography | – | GIS derivations | Geospatial GLM saturation proxies [@zhu2015] |
+
+## 3. Modelled variables & outputs
+
+| Output | Producing model | Units / dims | Meaning | Primary use |
+|---|---|---|---|---|
+| **$P(\text{liq})$** | GLM surrogate [@sanger2025jgge] | 0–1, `[y,x]` (event) / `[lead,y,x]` | probability of liquefaction | **Primary hazard target** |
+| Liquefaction areal extent | GLM | fraction / km² | spatial extent | loss estimation |
+| LPI / LSN | manifestation model [@iwasaki1978; @vanballegooy2014] | index | surface severity | damage / impact |
+| Return-period liquefaction hazard | unconditional integration over NSHM | annual rate / 50-yr prob. | $\lambda_{liq}$ | planning baseline |
+
+## 4. Data-prep pipeline
+
+```
+A. domain     AOI / region; target CRS + resolution (high-res even for static layers)
+B. acquire    Vs30/Vs profiles · water table (Pillar 1) · geology · ShakeMap|NSHM ground motion
+C. harmonize  reproject + resample to one grid contract; record manifest + provenance
+D. derive     effective stress σ'v (from water table) · Vs1 · CSR · saturation proxies
+E. condition  conditional GLM P(liq|IM)  →  (unconditional: integrate over NSHM;
+                                              event: apply ShakeMap IM field)
+F. dynamic    couple groundwater (sea-level / seasonal) + time-varying Vs/κ0 (§5 open question)
+G. validate   input contract: shape · CRS · units · required fields
+H. publish    COG / Zarr on s3://cresst + STAC items with source·measurement·res·uncertainty
+```
+
+The **high-resolution requirement** (even for static $V_{s30}$, geology, water table) is central:
+liquefaction is controlled by meter-scale contrasts, so coarse inputs systematically smear hazard
+and bias loss estimates (see [Pillar 2 §3](pillar-2-nowcasting-susceptibility)).
+
+## 5. Known gaps, risks & sensitivities
+
+- **Static vs dynamic water table.** Most GLMs use a *modeled, static* water table; GAIA's
+  contribution is the **dynamic** $d_{wt}$ (seasonal, sea-level rise) from Pillar 1 — the
+  inventory must distinguish the two.
+- **Time-varying site term.** $\kappa_0(t)$ / $V_s(t)$ are not yet wired into the NSHM-based
+  unconditional product (the open question in [model §5](modelhub-liquefaction)).
+- **$V_{s30}$ proxy uncertainty.** Slope/geology-based $V_{s30}$ carries large scatter; the
+  parametric profiles [@sanger2025vs] reduce but do not remove it.
+- **Training transferability.** Geospatial GLMs trained on one region (e.g. Christchurch, Kobe)
+  need regional efficacy checks before PNW use [@rashidian2020; @geyin2020field].
+- **Ground-motion epistemic uncertainty.** ShakeMap and GMM/NSHM uncertainty propagate directly
+  into the demand side.
+
+## Related
+
+- [Liquefaction & Ground Failure](hazard-liquefaction-ground-failure) — the hazard page this
+  inventory serves.
+- [Liquefaction Model](modelhub-liquefaction) — the model that consumes these layers.
+- [DataHub](datahub) · [DataHub Integration Guide](datahub-integration-guide) — platform,
+  provenance standard, and repo migration path.
+- [Landslide Data Inventory](datahub-landslide-inventory) — the sibling inventory; shared layers
+  (DEM, water table, saturation, precipitation) are tagged across both.
+- [Pillar 1 — Soil Reanalysis Product](pillar-1-soil-reanalysis) — the dynamic water-table source.
+- Repos: [`da-seis-groundfailure`](https://github.com/gaia-hazlab/da-seis-groundfailure) ·
+  [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) ·
+  [`gaia-cli`](https://github.com/gaia-hazlab/gaia-cli) · `gaia-model-liquefaction` *(proposed)* ·
+  `gaia-vs-conus` *(proposed)*.

--- a/book/chapters/hazard-liquefaction-ground-failure.md
+++ b/book/chapters/hazard-liquefaction-ground-failure.md
@@ -2,10 +2,10 @@
 
 :::{note}
 **Draft / scaffold.** Hazard target of the [Digital Twin Framework](digital-twin-overview).
-The full modeling track — the geospatial liquefaction model (GLM) digital twin, fundamental
-equations, the conditional/unconditional/event-based framings, attenuation, and the data
-inventory — is developed in
-[Pillar 2 §3](pillar-2-nowcasting-susceptibility).
+The full modeling track is developed across three pages: the science overview in
+[Pillar 2 §3](pillar-2-nowcasting-susceptibility), the geospatial liquefaction model (GLM) on
+the [Liquefaction Model](modelhub-liquefaction) page, and the layer-by-layer
+[Liquefaction Data Inventory](datahub-liquefaction-inventory).
 :::
 
 ## Scientific framing

--- a/book/chapters/hazard-liquefaction-ground-failure.md
+++ b/book/chapters/hazard-liquefaction-ground-failure.md
@@ -2,7 +2,10 @@
 
 :::{note}
 **Draft / scaffold.** Hazard target of the [Digital Twin Framework](digital-twin-overview).
-Follows the standard hazard-page template.
+The full modeling track — the geospatial liquefaction model (GLM) digital twin, fundamental
+equations, the conditional/unconditional/event-based framings, attenuation, and the data
+inventory — is developed in
+[Pillar 2 §3](pillar-2-nowcasting-susceptibility).
 :::
 
 ## Scientific framing

--- a/book/chapters/modelhub-liquefaction.md
+++ b/book/chapters/modelhub-liquefaction.md
@@ -1,0 +1,190 @@
+# Liquefaction Model — Geospatial GLM Surrogate
+
+:::{note}
+**The model-side companion to the liquefaction digital twin.** This page is the ModelHub home
+for the **geospatial liquefaction model (GLM)**: the equations it solves, what is *solved*
+versus *assumed* inside a geospatial surrogate, the three hazard framings
+(conditional / unconditional / event-based), how attenuation and the National Seismic Hazard
+Model enter, how it couples to the other GAIA projects (soil reanalysis, the landslide model,
+earthquake wavefields), how to make it interoperable with **Earth2Studio**, and how predictions
+are evaluated.
+
+It builds on the science in [Pillar 2 §3](pillar-2-nowcasting-susceptibility), draws on the
+state from [Pillar 1](pillar-1-soil-reanalysis), and reads the data cataloged in the
+[Liquefaction Data Inventory](datahub-liquefaction-inventory). Led by the **Sanger/Maurer**
+line of work [@sanger2025jgge; @sanger2026geoai]. Repository pointers in §9 are **placeholders**
+for the team (Morgan) to confirm.
+:::
+
+## 1. What the model computes (and what it does not)
+
+The product is the **probability and areal extent of liquefaction** and its surface
+**manifestation severity**, served in three framings (§4): conditional on a ground motion,
+unconditional over a return period, and for a specific event. A **geospatial** model trades
+per-site borehole data for spatially continuous proxies — predicting liquefaction from PGV/PGA,
+$V_{s30}$, water-table depth, precipitation, and distance to water [@zhu2015; @zhu2017] — so it
+covers regions where site investigations do not exist.
+
+What the model does **not** do: it does not replace site-specific CPT/SPT triggering analysis
+at an engineered site; it does not solve transient 3-D groundwater flow (it *consumes* a
+water-table field, §6); and it does not by itself produce ground motion — that comes from a
+ShakeMap (event) or the NSHM (probabilistic), §4–§5.
+
+## 2. The physics — the equations we solve
+
+The simplified procedure [@seedidriss1971; @idrissboulanger2006] compares seismic **demand** to
+soil **capacity**. The cyclic stress ratio (demand) is
+
+$$
+\mathrm{CSR} = 0.65\,\frac{a_{max}}{g}\,\frac{\sigma_{v0}}{\sigma'_{v0}}\,r_d ,
+$$
+
+the cyclic resistance ratio $\mathrm{CRR}$ is the capacity, and triggering is expected when the
+factor of safety
+
+$$
+\mathrm{FS}_{liq} = \frac{\mathrm{CRR}}{\mathrm{CSR}} \le 1 .
+$$
+
+Surface severity is summarized by manifestation indices — the Liquefaction Potential Index
+[@iwasaki1978] and the Liquefaction Severity Number [@vanballegooy2014]. Two **Pillar-1 state
+variables** enter directly:
+
+- **Hydrology (water table).** Pore pressure sets the effective stress
+  $\sigma'_{v0}=\sigma_{v0}-u$, which appears in *both* demand (the $\sigma_{v0}/\sigma'_{v0}$
+  ratio in CSR) and capacity (overburden correction of $V_{s1}$). Only **saturated** soil below
+  the water table can liquefy — saturation is a binary gate. A shallower water table raises
+  demand and exposes more liquefiable column.
+- **Rigidity (shear-wave velocity).** $V_s$ is the small-strain stiffness proxy
+  ($G_{max}=\rho V_s^2$). It raises **capacity** — CRR increases with overburden-corrected
+  $V_{s1}$ [@andrusstokoe2000] — and modulates **demand**, because $V_{s30}$ controls site
+  amplification of $a_{max}$. Stiffer ground resists triggering, but soft sites amplify shaking.
+
+## 3. The geospatial surrogate — what is solved vs. assumed
+
+Classical triggering (§2) is evaluated per soil column. The **geospatial** model regresses the
+*outcome* (liquefaction occurrence / manifestation) on spatially available proxies, and GAIA's
+GLM uses the **mechanics-informed ML surrogate** of [@sanger2025jgge], which emulates
+physics-based triggering at national scale and in near-real time, demonstrated for the PNW in
+[@sanger2026geoai].
+
+| Element | What it *solves* | What it *assumes* |
+|---|---|---|
+| Geospatial predictors → $P(\text{liq})$ | logistic / ML mapping from PGV, $V_{s30}$, water table, precip, distance-to-water [@zhu2017] | proxies stand in for unmeasured geotechnical state; training-region transferability [@rashidian2020] |
+| Mechanics-informed surrogate | fast emulation of the simplified-procedure FS over a region [@sanger2025jgge] | the surrogate is trained on / constrained by the mechanics; valid within its training envelope |
+| Manifestation model | fragility from FS / LPI to damage state [@geyin2020fragility; @geyin2020field; @maurer2015] | surface manifestation is a function of integrated triggering + site |
+| $V_s$ field | parametric CONUS $V_s$ profiles [@sanger2025vs] | functional form + geospatial ML capture the near-surface profile |
+
+The surrogate's value is **speed and coverage**: it runs the conditional model everywhere, fast
+enough for the unconditional integral (§4) and for Earth2Studio ensembles (§7).
+
+## 4. The three hazard framings
+
+A GLM digital twin must serve three distinct questions, each with different ground-motion input
+and data/model need:
+
+| Framing | Question | Ground-motion input | Output | Data / model need |
+|---|---|---|---|---|
+| **Conditional (national)** | $P(\text{liq}\mid IM)$ — given shaking | a specified IM (PGA/PGV) | probability / extent given that IM | the national GLM surrogate [@sanger2025jgge]; high-res $V_{s30}$, water table, geology |
+| **Unconditional (return period)** | total liquefaction hazard in $T$ years | integrated over the **NSHM** hazard curve | return-period liquefaction hazard | $\lambda_{liq}=\int P(\text{liq}\mid IM)\,\lvert d\lambda(IM)\rvert$; NSHM curves [@petersen2024] via [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) |
+| **Event-based (scenario)** | liquefaction footprint of *this* quake | a ShakeMap IM field | deterministic spatial map | rupture → ShakeMap → GLM; the nowcasting mode |
+
+The **unconditional** product is the "total risk for a return period" baseline; the
+**event-based** product is the real-time nowcast for a specific rupture (e.g. a Cascadia or
+[Nisqually](wa-2001-2031-nisqually-earthquake) scenario). All three call the *same* conditional
+surrogate — they differ only in how the ground motion is supplied and integrated.
+
+## 5. Attenuation, $\kappa_0$, and the NSHM
+
+High-frequency ground motion — and therefore $a_{max}$ — is controlled by **attenuation**,
+parameterized by the site spectral-decay term $\kappa_0$ [@andersonhough1984]. Two questions
+the GAIA seismic networks help answer:
+
+- **Where is $\kappa_0$ measured?** From the high-frequency slope of recorded acceleration
+  spectra ($A(f)\propto e^{-\pi\kappa f}$); the zero-distance intercept is the site $\kappa_0$.
+  GAIA's dense seismic/DAS data make this estimable per site.
+- **Can $\kappa_0$ vary in time?** It is dominated by attenuation in the shallow,
+  moisture-sensitive subsurface, so it is **not** strictly static — seasonal variation has been
+  observed [@haendel2025; @ktenidou2015]. This couples to the Pillar-1 soil reanalysis (the same
+  near-surface saturation GAIA monitors via $dv/v$).
+
+**Open integration question.** The [NSHM](https://www.usgs.gov/programs/earthquake-hazards)
+embeds a *fixed* reference-rock $\kappa_0$ and $V_{s30}$ site term [@petersen2024]; how to feed a
+**time-varying** site term ($\kappa_0(t)$, $V_s(t)$) back into the hazard input for the
+unconditional product (§4) is unresolved and a GAIA research target.
+
+## 6. Coupling map — where the other GAIA projects plug in
+
+**(a) Soil reanalysis** ([Pillar 1](pillar-1-soil-reanalysis), [soil-memory](soil-memory)). The
+water-table depth $d_{wt}(x,t)$ and saturation $S_w$ are the **dynamic** liquefaction controls
+(§2); the seismic $dv/v$ inversion also delivers a **time-varying $V_s$** for both the capacity
+term and the site amplification. This is the direct line from the reanalysis to liquefaction
+susceptibility, and the route by which **sea-level rise and seasonal water-table change** modulate
+hazard (via the [groundwater modeling](groundwater-soil-moisture)).
+
+**(b) The landslide model** ([modelhub-landslide](modelhub-landslide)). Liquefaction and
+landslides share the **same antecedent hydromechanical state** — saturation and water table —
+but couple it to a *seismic* trigger (PGA/PGV) rather than rainfall recharge. The landslide
+engine's **Monte-Carlo-over-uncertain-strength** structure is the template the liquefaction
+surrogate mirrors: both are "soil state + trigger → probability of failure."
+
+**(c) Earthquake wavefields & the NSHM.** The ground-motion field comes from ShakeMap (event) or
+the NSHM (probabilistic, via [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg));
+GAIA's wavefield reconstruction/forecasting work is the natural source of refined, possibly
+time-varying, site ground motion.
+
+## 7. Interoperability with Earth2Studio
+
+The **dynamic** half of the GLM twin needs forecast forcing, routed through
+[Earth2Studio](https://github.com/NVIDIA/earth2studio) — the same AI weather/climate stack the
+[landslide model](modelhub-landslide) and [Pillar 3 forecasting](pillar-3-forecasting-susceptibility)
+use:
+
+- **Climate/weather → groundwater → water table.** Earth2Studio forecasts (precipitation, plus
+  sea-level-rise and seasonal scenarios) drive the groundwater model that sets $d_{wt}$ — the
+  dynamic liquefaction control.
+- **GLM surrogate as a diagnostic model.** The fast mechanics-informed surrogate
+  [@sanger2025jgge] can be wrapped with the Earth2Studio diagnostic signature for large scenario
+  / return-period ensembles on GPU.
+- **Time-varying site terms.** Seismic-derived $V_s(t)$ / $\kappa_0(t)$ feed the ground-motion
+  side (§5), closing the dynamic loop.
+
+## 8. Evaluation & metrics
+
+As for the landslide model, separate **calibration** of intermediate states from **validation**
+of the prediction; full metric definitions live in [HazEvalHub](hazevalhub).
+
+- **Calibration** — against the geotechnical case-history record (CPT/SPT triggering, manifestation
+  fragility [@geyin2020fragility; @maurer2015]) and the $V_s$ / water-table inputs.
+- **Validation** — against **observed liquefaction maps** from past earthquakes (the
+  [Nisqually](wa-2001-2031-nisqually-earthquake) 2001 event is the regional target): probabilistic
+  skill (Brier, reliability), spatial agreement (IoU) of mapped manifestation, and — for the
+  unconditional product — consistency with return-period expectations.
+
+## 9. Repositories *(placeholders — for Morgan to confirm)*
+
+- [`da-seis-groundfailure`](https://github.com/gaia-hazlab/da-seis-groundfailure) — the
+  liquefaction / ground-failure modeling repo (hydrology + seismology + geotech).
+- [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) — USGS NSHM disaggregation
+  client feeding the unconditional integration.
+- `gaia-model-liquefaction` *(proposed)* — the GLM surrogate digital twin (conditional /
+  unconditional / event-based runners).
+- `gaia-vs-conus` *(proposed)* — the parametric $V_s$-profile product [@sanger2025vs].
+
+*Proposed repositories do not exist yet — the names are placeholders for the team to
+create/confirm.*
+
+## Related
+
+- [Pillar 2 — Nowcasting Hazard Susceptibility](pillar-2-nowcasting-susceptibility) — the science
+  framing.
+- [Pillar 1 — Soil Reanalysis Product](pillar-1-soil-reanalysis) ·
+  [Groundwater & Soil Moisture](groundwater-soil-moisture) — the soil state and water-table this
+  model consumes.
+- [Liquefaction & Ground Failure](hazard-liquefaction-ground-failure) — the hazard page.
+- [Liquefaction Data Inventory](datahub-liquefaction-inventory) — every input/output with sources,
+  resolution, and the data-prep pipeline.
+- [Landslide Model](modelhub-landslide) — the sibling model this one mirrors.
+- [HazEvalHub](hazevalhub) — metric definitions.
+
+## References

--- a/book/chapters/pillar-2-nowcasting-susceptibility.md
+++ b/book/chapters/pillar-2-nowcasting-susceptibility.md
@@ -130,6 +130,10 @@ RAW INPUTS ──► DERIVED / INTERMEDIATE FIELDS ──► PREDICTION ──�
 | **Probability of failure $P_f$** | **PREDICTION** | `LandslideProbability` | — | The nowcast product |
 | Landslide masks / inventories | **LABEL** | Sentinel SAR/InSAR & optical [@mondini2021; @handwerger2022]; post-event DEM/lidar differencing [@bernard2021] | Varies | Used only to **score** $P_f$ (§2.6) — not a model input |
 
+Several of these layers (DEM, soil saturation, water table, precipitation) are **shared with
+other hazards**. The consolidated, icon-tagged cross-hazard inventory — marking which layer
+serves landslides, post-fire debris flows, liquefaction, or floods — is in §3.6.
+
 ### 2.5 The prediction pipeline
 
 Landslide probability is produced by
@@ -184,25 +188,156 @@ The current names obscure what the repos do and should be clarified (tracked in 
   preparation** → suggest **`gaia-dataprep-landslide`**.
 - This makes the **data-prep (Pillar 1) → model (Pillar 2)** split explicit in the repo names.
 
-## 3. Liquefaction & ground failure *(next pass)*
+## 3. Liquefaction & ground failure
 
 :::{note}
-**Scoped, scheduled for a later pass this week.** Led by the Sanger/Maurer line of work.
+**In development (liquefaction track), led by the Sanger/Maurer line of work.** Repository
+pointers in §3.8 are **placeholders** for the team (Morgan) to confirm.
 :::
 
-We will model earthquake-triggered liquefaction and ground failure
-([hazard page](hazard-liquefaction-ground-failure)) building on geospatial surrogate models
-for liquefaction hazard and impact [@sanger2025jgge; @sanger2026geoai; @sanger2026geocongress]
-and parametric $V_s$ profiles [@sanger2025vs]. Two concrete next steps:
+Earthquake shaking can turn saturated, loose granular soils into a fluid-like state —
+liquefaction — driving settlement, lateral spreading, and ground failure
+([hazard page](hazard-liquefaction-ground-failure)). Unlike landslides, the trigger is
+**seismic**, not meteorological; but the *susceptibility* is set by the same Pillar-1 state —
+saturation and water-table depth — coupled to the soil's stiffness. GAIA builds a **ground
+liquefaction model (GLM) digital twin** on the geospatial-modeling line of [@zhu2015; @zhu2017]
+as advanced by Sanger, Geyin & Maurer
+[@sanger2025jgge; @sanger2026geoai; @sanger2026geocongress; @sanger2025vs].
 
-1. **Unconditional liquefaction susceptibility** — the geospatial baseline independent of a
-   specific earthquake.
-2. **Couple groundwater-level modeling** (see [Groundwater & Soil Moisture](groundwater-soil-moisture))
-   to assess how **long-term sea-level rise and seasonal water-table variations** modulate
-   liquefaction — drawing directly on the Pillar-1 water-table product.
+### 3.1 The geospatial liquefaction model (GLM)
 
-This will require adding the corresponding geotechnical and groundwater layers to the
-[DataHub](datahub) inventory and a liquefaction modeling component in [ModelHub](modelhub).
+Classical liquefaction assessment is site-specific (borehole CPT/SPT). **Geospatial** models
+trade per-site geotechnical data for spatially continuous proxies — predicting the probability
+and areal extent of liquefaction from PGV/PGA, $V_{s30}$, modeled water-table depth,
+precipitation, and distance to water [@zhu2017; @rashidian2020], with manifestation severity
+captured by fragility functions [@geyin2020fragility; @geyin2020field]. GAIA's GLM uses the
+mechanics-informed ML surrogates of [@sanger2025jgge], which emulate physics-based triggering
+at national scale and in near-real time, demonstrated for the PNW in [@sanger2026geoai].
+
+### 3.2 Fundamental equations — where hydrology and rigidity enter
+
+The simplified procedure [@seedidriss1971; @idrissboulanger2006] compares seismic **demand**
+to soil **capacity**. Demand is the cyclic stress ratio,
+
+$$ \mathrm{CSR} = 0.65\,\frac{a_{max}}{g}\,\frac{\sigma_{v0}}{\sigma'_{v0}}\,r_d, $$
+
+capacity is the cyclic resistance ratio $\mathrm{CRR}$, and triggering is expected when
+
+$$ \mathrm{FS}_{liq} = \frac{\mathrm{CRR}}{\mathrm{CSR}} \le 1. $$
+
+Surface severity is summarized by manifestation indices — LPI [@iwasaki1978] and LSN
+[@vanballegooy2014]. Two **Pillar-1 state variables** enter the physics directly:
+
+- **Hydrology (water table).** Pore pressure sets the effective stress
+  $\sigma'_{v0}=\sigma_{v0}-u$, which appears in *both* demand (the $\sigma_{v0}/\sigma'_{v0}$
+  ratio in CSR) and capacity (overburden correction of $V_{s1}$). Only **saturated** soil below
+  the water table can liquefy — saturation is a binary gate. A shallower water table raises
+  demand and exposes more liquefiable column. This is the direct consumer of the Pillar-1
+  **water-table product** and the [groundwater modeling](groundwater-soil-moisture).
+- **Rigidity (shear-wave velocity).** $V_s$ is the small-strain stiffness proxy
+  ($G_{max}=\rho V_s^2$). It enters **capacity** — CRR rises with overburden-corrected $V_{s1}$
+  [@andrusstokoe2000] — *and* **demand**, because $V_{s30}$ controls site amplification of
+  $a_{max}$. Stiffer ground resists triggering, but soft sites amplify shaking. GAIA's $V_s$
+  comes from the parametric CONUS profiles of [@sanger2025vs] and, dynamically, from the
+  seismic monitoring of [soil-memory](soil-memory).
+
+### 3.3 Three hazard framings: conditional, unconditional, event-based
+
+A GLM digital twin must serve three distinct questions, each with different data and modeling
+needs:
+
+| Framing | Question | Ground-motion input | Output | Data / model need |
+|---|---|---|---|---|
+| **Conditional (national)** | $P(\text{liq}\mid IM)$ — given shaking | a specified intensity measure (PGA/PGV) | probability / extent given that IM | the national GLM surrogate [@sanger2025jgge]; geospatial $V_{s30}$, water table |
+| **Unconditional (return period)** | total liquefaction hazard in $T$ years | integrated over the **NSHM** hazard curve | return-period liquefaction hazard | $\lambda_{liq}=\int P(\text{liq}\mid IM)\,\lvert d\lambda(IM)\rvert$; NSHM curves [@petersen2024] via [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) |
+| **Event-based (scenario)** | liquefaction footprint of *this* quake | a ShakeMap IM field | deterministic spatial map | rupture → ShakeMap → GLM; the nowcasting mode |
+
+The **unconditional** product is the "total risk for a return period" baseline; the
+**event-based** product is the real-time nowcast for a specific rupture (e.g. a Cascadia or
+[Nisqually](wa-2001-2031-nisqually-earthquake) scenario).
+
+### 3.4 Attenuation, $\kappa_0$, and the NSHM (an open question)
+
+High-frequency ground motion — and therefore $a_{max}$ — is controlled by **attenuation**,
+parameterized by the site spectral-decay term $\kappa_0$ [@andersonhough1984]. The GAIA
+seismic networks can help answer two questions the team has flagged:
+
+- **Where is $\kappa_0$ measured?** From the high-frequency slope of recorded acceleration
+  spectra ($A(f)\propto e^{-\pi\kappa f}$); the zero-distance intercept is the site $\kappa_0$.
+  GAIA's dense seismic/DAS data make this estimable per site.
+- **Can $\kappa_0$ vary in time?** It is dominated by attenuation in the shallow,
+  moisture-sensitive subsurface, so it is **not** strictly static — seasonal variation has been
+  observed [@haendel2025; @ktenidou2015]. This is a natural coupling to the Pillar-1 soil
+  reanalysis (the same near-surface saturation GAIA monitors via $dv/v$). **Open integration
+  question:** the [NSHM](https://www.usgs.gov/programs/earthquake-hazards) embeds a *fixed*
+  reference-rock $\kappa_0$ and $V_{s30}$ site term [@petersen2024]; how to feed a
+  **time-varying** site term back into the hazard input for the unconditional product is
+  unresolved and a GAIA research target.
+
+### 3.5 Why high-resolution GLMs — even for static layers
+
+A national GLM cannot be coarse. Liquefaction is controlled by **meter-scale** contrasts in
+saturation, $V_s$, and geology, so even the **static but spatially-resolved** layers
+($V_{s30}$, geology, water-table depth) must be high-resolution — otherwise the inputs average
+away the very heterogeneity that localizes ground failure, systematically smearing hazard and
+biasing loss estimates. This is the same resolution argument made for the
+[soil reanalysis](pillar-1-soil-reanalysis). On top of the static layers, GAIA adds **dynamic,
+time-varying** hydrological (water table from sea-level rise and seasonal recharge) and
+mechanical ($V_s$, $\kappa_0$) effects — the novel contribution beyond a static national map.
+
+### 3.6 Data inventory (cross-checked against landslides)
+
+Every layer is tagged with the hazard purpose it serves, so the [DataHub](datahub) inventory is
+shared and de-duplicated across hazards.
+
+**Legend:** ⛰️ landslides (shallow/deep) · 🔥 post-fire debris flows · 🏚️ liquefaction &
+ground failure · 🌊 floods
+
+| Layer | Role | Source | Serves |
+|---|---|---|---|
+| DEM / terrain (slope, CTI) | static | USGS 3DEP | ⛰️ 🔥 🏚️ 🌊 |
+| $V_{s30}$ / $V_s$ profiles | static → dynamic | [@sanger2025vs]; seismic ([soil-memory](soil-memory)) | 🏚️ ⛰️ |
+| Water-table depth $d_{wt}$ | **dynamic** | [Pillar 1](pillar-1-soil-reanalysis); [groundwater modeling](groundwater-soil-moisture) | 🏚️ ⛰️ 🌊 |
+| Soil saturation $S_w$ | **dynamic** | [Pillar 1](pillar-1-soil-reanalysis) | ⛰️ 🔥 🏚️ 🌊 |
+| Surficial geology / soil type | static | SOLUS / POLARIS, state surveys | 🏚️ ⛰️ |
+| Precipitation | dynamic | PRISM / HRRR (gaia-cli) | ⛰️ 🔥 🌊 |
+| Ground motion (PGA/PGV) | event / probabilistic | ShakeMap; NSHM [@petersen2024] | 🏚️ |
+| $\kappa_0$ / attenuation | static → dynamic | seismic spectra [@andersonhough1984] | 🏚️ |
+| Burn severity (dNBR) | static (per event) | MTBS / BAER | 🔥 |
+
+The **water-table** and **saturation** rows are exactly the layers shared with the landslide
+data taxonomy (§2.4) — the soil reanalysis serves both hazards, which is why the inventory and
+icons are unified rather than per-hazard.
+
+### 3.7 Integration with Earth2Studio
+
+The **dynamic** half of the GLM twin needs forecast forcing, routed through
+[NVIDIA Earth2Studio](https://github.com/gaia-hazlab/earth2studio-test) — the same AI
+weather/climate stack the
+[landslide digital twin](https://github.com/gaia-hazlab/landslide-digital-twin) and
+[Pillar 3 forecasting](pillar-3-forecasting-susceptibility) use:
+
+- **Climate/weather → groundwater → water table.** Earth2Studio forecasts (precipitation, plus
+  sea-level-rise and seasonal scenarios) drive the groundwater model that sets $d_{wt}$ — the
+  dynamic liquefaction control.
+- **GLM surrogate as an Earth2Studio model.** The fast mechanics-informed surrogate
+  [@sanger2025jgge] can be wrapped as a pipeline component for large scenario / return-period
+  ensembles.
+- **Time-varying site terms.** Seismic-derived $V_s(t)$ / $\kappa_0(t)$ feed the ground-motion
+  side, closing the dynamic loop (§3.4).
+
+### 3.8 Repositories *(placeholders — for Morgan to confirm)*
+
+- [`da-seis-groundfailure`](https://github.com/gaia-hazlab/da-seis-groundfailure) — the
+  liquefaction / ground-failure modeling repo (hydrology + seismology + geotech).
+- [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) — USGS NSHM disaggregation
+  client feeding the unconditional integration.
+- `gaia-model-liquefaction` *(proposed)* — the GLM surrogate digital twin (conditional /
+  unconditional / event-based runners).
+- `gaia-vs-conus` *(proposed)* — the parametric $V_s$-profile product [@sanger2025vs].
+
+*Proposed repositories do not exist yet — the names are placeholders for the team to
+create/confirm.*
 
 ## 4. Evaluation & metrics
 
@@ -212,9 +347,11 @@ time.
 
 ## 5. Open questions & roadmap
 
-- Split the landslide hazard pages into the three process-specific subpages (§2.1).
 - Quantify how prior uncertainty in static soil layers propagates to $P_f$ (sensitivity study).
 - Close the Pillar 1 → Pillar 2 data loop by migrating `landlab-debrisflow` onto DataHub.
-- Stand up the liquefaction track (§3).
+- Liquefaction: integrate a **time-varying** site term ($\kappa_0(t)$, $V_s(t)$) into the NSHM
+  hazard input for the unconditional product (§3.4).
+- Liquefaction: stand up the proposed repositories (§3.8) and the groundwater coupling for
+  sea-level-rise/seasonal effects.
 
 ## References

--- a/book/chapters/pillar-2-nowcasting-susceptibility.md
+++ b/book/chapters/pillar-2-nowcasting-susceptibility.md
@@ -19,7 +19,8 @@ build on. Two hazard tracks are in scope:
 
 - **(a) Landslides** — advanced; modeled with Landlab — full equations, pipeline, and limits on
   the [Landslide Model](modelhub-landslide) page (§2).
-- **(b) Liquefaction & ground failure** — scoped, next pass (§3).
+- **(b) Liquefaction & ground failure** — in development; overview in §3, full model on the
+  [Liquefaction Model](modelhub-liquefaction) page (§3).
 
 ## 2. Landslides
 
@@ -131,8 +132,10 @@ RAW INPUTS ──► DERIVED / INTERMEDIATE FIELDS ──► PREDICTION ──�
 | Landslide masks / inventories | **LABEL** | Sentinel SAR/InSAR & optical [@mondini2021; @handwerger2022]; post-event DEM/lidar differencing [@bernard2021] | Varies | Used only to **score** $P_f$ (§2.6) — not a model input |
 
 Several of these layers (DEM, soil saturation, water table, precipitation) are **shared with
-other hazards**. The consolidated, icon-tagged cross-hazard inventory — marking which layer
-serves landslides, post-fire debris flows, liquefaction, or floods — is in §3.6.
+other hazards**. The full layer-by-layer catalog is the
+[Landslide Data Inventory](datahub-landslide-inventory); the
+[Liquefaction Data Inventory](datahub-liquefaction-inventory) carries hazard-purpose icons
+(⛰️ 🔥 🏚️ 🌊) marking which layer serves which hazard.
 
 ### 2.5 The prediction pipeline
 
@@ -191,8 +194,9 @@ The current names obscure what the repos do and should be clarified (tracked in 
 ## 3. Liquefaction & ground failure
 
 :::{note}
-**In development (liquefaction track), led by the Sanger/Maurer line of work.** Repository
-pointers in §3.8 are **placeholders** for the team (Morgan) to confirm.
+**In development (liquefaction track), led by the Sanger/Maurer line of work.** The full model
+treatment is on the [Liquefaction Model](modelhub-liquefaction) page; the layer-by-layer data on
+the [Liquefaction Data Inventory](datahub-liquefaction-inventory) page.
 :::
 
 Earthquake shaking can turn saturated, loose granular soils into a fluid-like state —
@@ -201,143 +205,32 @@ liquefaction — driving settlement, lateral spreading, and ground failure
 **seismic**, not meteorological; but the *susceptibility* is set by the same Pillar-1 state —
 saturation and water-table depth — coupled to the soil's stiffness. GAIA builds a **ground
 liquefaction model (GLM) digital twin** on the geospatial-modeling line of [@zhu2015; @zhu2017]
-as advanced by Sanger, Geyin & Maurer
-[@sanger2025jgge; @sanger2026geoai; @sanger2026geocongress; @sanger2025vs].
+as advanced by Sanger, Geyin & Maurer [@sanger2025jgge; @sanger2026geoai; @sanger2025vs].
 
-### 3.1 The geospatial liquefaction model (GLM)
+**Where hydrology and rigidity enter.** Liquefaction is governed by the cyclic stress ratio
+(demand) versus the cyclic resistance ratio (capacity),
+$\mathrm{FS}_{liq}=\mathrm{CRR}/\mathrm{CSR}$ [@seedidriss1971; @idrissboulanger2006]. The
+**water table** sets effective stress $\sigma'_{v0}$ (in both demand and capacity) and gates
+which soil is saturated enough to liquefy; **shear-wave velocity** $V_s$ raises capacity (CRR)
+and modulates demand through site amplification [@andrusstokoe2000]. Both are Pillar-1 state
+variables — the direct line by which the soil reanalysis, and **sea-level rise / seasonal
+water-table change**, modulate liquefaction.
 
-Classical liquefaction assessment is site-specific (borehole CPT/SPT). **Geospatial** models
-trade per-site geotechnical data for spatially continuous proxies — predicting the probability
-and areal extent of liquefaction from PGV/PGA, $V_{s30}$, modeled water-table depth,
-precipitation, and distance to water [@zhu2017; @rashidian2020], with manifestation severity
-captured by fragility functions [@geyin2020fragility; @geyin2020field]. GAIA's GLM uses the
-mechanics-informed ML surrogates of [@sanger2025jgge], which emulate physics-based triggering
-at national scale and in near-real time, demonstrated for the PNW in [@sanger2026geoai].
+**Three framings.** The GLM digital twin serves three questions — **conditional**
+($P(\text{liq}\mid IM)$, the national surrogate), **unconditional** (integrated over the NSHM
+hazard curve for a return period), and **event-based** (a ShakeMap field for a specific rupture,
+e.g. Cascadia or [Nisqually](wa-2001-2031-nisqually-earthquake)). A distinctive open question is
+whether a **time-varying attenuation / site term** ($\kappa_0(t)$, $V_s(t)$) — which the GAIA
+seismic networks can estimate and which varies seasonally [@haendel2025] — can be fed back into
+the fixed-site-term NSHM.
 
-### 3.2 Fundamental equations — where hydrology and rigidity enter
-
-The simplified procedure [@seedidriss1971; @idrissboulanger2006] compares seismic **demand**
-to soil **capacity**. Demand is the cyclic stress ratio,
-
-$$ \mathrm{CSR} = 0.65\,\frac{a_{max}}{g}\,\frac{\sigma_{v0}}{\sigma'_{v0}}\,r_d, $$
-
-capacity is the cyclic resistance ratio $\mathrm{CRR}$, and triggering is expected when
-
-$$ \mathrm{FS}_{liq} = \frac{\mathrm{CRR}}{\mathrm{CSR}} \le 1. $$
-
-Surface severity is summarized by manifestation indices — LPI [@iwasaki1978] and LSN
-[@vanballegooy2014]. Two **Pillar-1 state variables** enter the physics directly:
-
-- **Hydrology (water table).** Pore pressure sets the effective stress
-  $\sigma'_{v0}=\sigma_{v0}-u$, which appears in *both* demand (the $\sigma_{v0}/\sigma'_{v0}$
-  ratio in CSR) and capacity (overburden correction of $V_{s1}$). Only **saturated** soil below
-  the water table can liquefy — saturation is a binary gate. A shallower water table raises
-  demand and exposes more liquefiable column. This is the direct consumer of the Pillar-1
-  **water-table product** and the [groundwater modeling](groundwater-soil-moisture).
-- **Rigidity (shear-wave velocity).** $V_s$ is the small-strain stiffness proxy
-  ($G_{max}=\rho V_s^2$). It enters **capacity** — CRR rises with overburden-corrected $V_{s1}$
-  [@andrusstokoe2000] — *and* **demand**, because $V_{s30}$ controls site amplification of
-  $a_{max}$. Stiffer ground resists triggering, but soft sites amplify shaking. GAIA's $V_s$
-  comes from the parametric CONUS profiles of [@sanger2025vs] and, dynamically, from the
-  seismic monitoring of [soil-memory](soil-memory).
-
-### 3.3 Three hazard framings: conditional, unconditional, event-based
-
-A GLM digital twin must serve three distinct questions, each with different data and modeling
-needs:
-
-| Framing | Question | Ground-motion input | Output | Data / model need |
-|---|---|---|---|---|
-| **Conditional (national)** | $P(\text{liq}\mid IM)$ — given shaking | a specified intensity measure (PGA/PGV) | probability / extent given that IM | the national GLM surrogate [@sanger2025jgge]; geospatial $V_{s30}$, water table |
-| **Unconditional (return period)** | total liquefaction hazard in $T$ years | integrated over the **NSHM** hazard curve | return-period liquefaction hazard | $\lambda_{liq}=\int P(\text{liq}\mid IM)\,\lvert d\lambda(IM)\rvert$; NSHM curves [@petersen2024] via [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) |
-| **Event-based (scenario)** | liquefaction footprint of *this* quake | a ShakeMap IM field | deterministic spatial map | rupture → ShakeMap → GLM; the nowcasting mode |
-
-The **unconditional** product is the "total risk for a return period" baseline; the
-**event-based** product is the real-time nowcast for a specific rupture (e.g. a Cascadia or
-[Nisqually](wa-2001-2031-nisqually-earthquake) scenario).
-
-### 3.4 Attenuation, $\kappa_0$, and the NSHM (an open question)
-
-High-frequency ground motion — and therefore $a_{max}$ — is controlled by **attenuation**,
-parameterized by the site spectral-decay term $\kappa_0$ [@andersonhough1984]. The GAIA
-seismic networks can help answer two questions the team has flagged:
-
-- **Where is $\kappa_0$ measured?** From the high-frequency slope of recorded acceleration
-  spectra ($A(f)\propto e^{-\pi\kappa f}$); the zero-distance intercept is the site $\kappa_0$.
-  GAIA's dense seismic/DAS data make this estimable per site.
-- **Can $\kappa_0$ vary in time?** It is dominated by attenuation in the shallow,
-  moisture-sensitive subsurface, so it is **not** strictly static — seasonal variation has been
-  observed [@haendel2025; @ktenidou2015]. This is a natural coupling to the Pillar-1 soil
-  reanalysis (the same near-surface saturation GAIA monitors via $dv/v$). **Open integration
-  question:** the [NSHM](https://www.usgs.gov/programs/earthquake-hazards) embeds a *fixed*
-  reference-rock $\kappa_0$ and $V_{s30}$ site term [@petersen2024]; how to feed a
-  **time-varying** site term back into the hazard input for the unconditional product is
-  unresolved and a GAIA research target.
-
-### 3.5 Why high-resolution GLMs — even for static layers
-
-A national GLM cannot be coarse. Liquefaction is controlled by **meter-scale** contrasts in
-saturation, $V_s$, and geology, so even the **static but spatially-resolved** layers
-($V_{s30}$, geology, water-table depth) must be high-resolution — otherwise the inputs average
-away the very heterogeneity that localizes ground failure, systematically smearing hazard and
-biasing loss estimates. This is the same resolution argument made for the
-[soil reanalysis](pillar-1-soil-reanalysis). On top of the static layers, GAIA adds **dynamic,
-time-varying** hydrological (water table from sea-level rise and seasonal recharge) and
-mechanical ($V_s$, $\kappa_0$) effects — the novel contribution beyond a static national map.
-
-### 3.6 Data inventory (cross-checked against landslides)
-
-Every layer is tagged with the hazard purpose it serves, so the [DataHub](datahub) inventory is
-shared and de-duplicated across hazards.
-
-**Legend:** ⛰️ landslides (shallow/deep) · 🔥 post-fire debris flows · 🏚️ liquefaction &
-ground failure · 🌊 floods
-
-| Layer | Role | Source | Serves |
-|---|---|---|---|
-| DEM / terrain (slope, CTI) | static | USGS 3DEP | ⛰️ 🔥 🏚️ 🌊 |
-| $V_{s30}$ / $V_s$ profiles | static → dynamic | [@sanger2025vs]; seismic ([soil-memory](soil-memory)) | 🏚️ ⛰️ |
-| Water-table depth $d_{wt}$ | **dynamic** | [Pillar 1](pillar-1-soil-reanalysis); [groundwater modeling](groundwater-soil-moisture) | 🏚️ ⛰️ 🌊 |
-| Soil saturation $S_w$ | **dynamic** | [Pillar 1](pillar-1-soil-reanalysis) | ⛰️ 🔥 🏚️ 🌊 |
-| Surficial geology / soil type | static | SOLUS / POLARIS, state surveys | 🏚️ ⛰️ |
-| Precipitation | dynamic | PRISM / HRRR (gaia-cli) | ⛰️ 🔥 🌊 |
-| Ground motion (PGA/PGV) | event / probabilistic | ShakeMap; NSHM [@petersen2024] | 🏚️ |
-| $\kappa_0$ / attenuation | static → dynamic | seismic spectra [@andersonhough1984] | 🏚️ |
-| Burn severity (dNBR) | static (per event) | MTBS / BAER | 🔥 |
-
-The **water-table** and **saturation** rows are exactly the layers shared with the landslide
-data taxonomy (§2.4) — the soil reanalysis serves both hazards, which is why the inventory and
-icons are unified rather than per-hazard.
-
-### 3.7 Integration with Earth2Studio
-
-The **dynamic** half of the GLM twin needs forecast forcing, routed through
-[NVIDIA Earth2Studio](https://github.com/gaia-hazlab/earth2studio-test) — the same AI
-weather/climate stack the
-[landslide digital twin](https://github.com/gaia-hazlab/landslide-digital-twin) and
-[Pillar 3 forecasting](pillar-3-forecasting-susceptibility) use:
-
-- **Climate/weather → groundwater → water table.** Earth2Studio forecasts (precipitation, plus
-  sea-level-rise and seasonal scenarios) drive the groundwater model that sets $d_{wt}$ — the
-  dynamic liquefaction control.
-- **GLM surrogate as an Earth2Studio model.** The fast mechanics-informed surrogate
-  [@sanger2025jgge] can be wrapped as a pipeline component for large scenario / return-period
-  ensembles.
-- **Time-varying site terms.** Seismic-derived $V_s(t)$ / $\kappa_0(t)$ feed the ground-motion
-  side, closing the dynamic loop (§3.4).
-
-### 3.8 Repositories *(placeholders — for Morgan to confirm)*
-
-- [`da-seis-groundfailure`](https://github.com/gaia-hazlab/da-seis-groundfailure) — the
-  liquefaction / ground-failure modeling repo (hydrology + seismology + geotech).
-- [`gaia-nhsm-deagg`](https://github.com/gaia-hazlab/gaia-nhsm-deagg) — USGS NSHM disaggregation
-  client feeding the unconditional integration.
-- `gaia-model-liquefaction` *(proposed)* — the GLM surrogate digital twin (conditional /
-  unconditional / event-based runners).
-- `gaia-vs-conus` *(proposed)* — the parametric $V_s$-profile product [@sanger2025vs].
-
-*Proposed repositories do not exist yet — the names are placeholders for the team to
-create/confirm.*
+Even the **static** layers ($V_{s30}$, geology, water table) must be **high-resolution**:
+liquefaction is controlled by meter-scale contrasts, so coarse inputs smear hazard. On top of
+them GAIA adds the **dynamic** hydrological and mechanical effects. The full equations, the
+solved-vs-assumed breakdown, the framings in detail, attenuation, Earth2Studio integration, and
+evaluation are on the **[Liquefaction Model](modelhub-liquefaction)** page; the layer-by-layer
+data inventory (with cross-hazard icons) is on the
+**[Liquefaction Data Inventory](datahub-liquefaction-inventory)** page.
 
 ## 4. Evaluation & metrics
 
@@ -350,8 +243,8 @@ time.
 - Quantify how prior uncertainty in static soil layers propagates to $P_f$ (sensitivity study).
 - Close the Pillar 1 → Pillar 2 data loop by migrating `landlab-debrisflow` onto DataHub.
 - Liquefaction: integrate a **time-varying** site term ($\kappa_0(t)$, $V_s(t)$) into the NSHM
-  hazard input for the unconditional product (§3.4).
-- Liquefaction: stand up the proposed repositories (§3.8) and the groundwater coupling for
-  sea-level-rise/seasonal effects.
+  hazard input for the unconditional product (see [Liquefaction Model §5](modelhub-liquefaction)).
+- Liquefaction: stand up the proposed repositories and the groundwater coupling for
+  sea-level-rise/seasonal effects (see [Liquefaction Model §9](modelhub-liquefaction)).
 
 ## References

--- a/book/references.bib
+++ b/book/references.bib
@@ -490,3 +490,183 @@
   archivePrefix = {arXiv},
   doi           = {10.48550/arXiv.2510.00372}
 }
+
+% ---------------------------------------------------------------------------
+% Liquefaction track (Pillar 2b) — DOIs verified against Crossref unless noted.
+% ---------------------------------------------------------------------------
+
+% --- Geospatial liquefaction models (GLM) ---
+@article{zhu2017,
+  author  = {Zhu, Jing and Baise, Laurie G. and Thompson, Eric M.},
+  title   = {An Updated Geospatial Liquefaction Model for Global Application},
+  journal = {Bulletin of the Seismological Society of America},
+  year    = {2017},
+  volume  = {107},
+  number  = {3},
+  pages   = {1365--1385},
+  doi     = {10.1785/0120160198}
+}
+
+@article{zhu2015,
+  author  = {Zhu, Jing and Daley, Davene and Baise, Laurie G. and Thompson, Eric M. and Wald, David J. and Knudsen, Keith L.},
+  title   = {A Geospatial Liquefaction Model for Rapid Response and Loss Estimation},
+  journal = {Earthquake Spectra},
+  year    = {2015},
+  volume  = {31},
+  number  = {3},
+  pages   = {1813--1837},
+  doi     = {10.1193/121912EQS353M}
+}
+
+@article{rashidian2020,
+  author  = {Rashidian, Vahid and Baise, Laurie G.},
+  title   = {Regional efficacy of a global geospatial liquefaction model},
+  journal = {Engineering Geology},
+  year    = {2020},
+  volume  = {272},
+  pages   = {105644},
+  doi     = {10.1016/j.enggeo.2020.105644}
+}
+
+@article{geyin2020fragility,
+  author  = {Geyin, Mertcan and Maurer, Brett W.},
+  title   = {Fragility Functions for Liquefaction-Induced Ground Failure},
+  journal = {Journal of Geotechnical and Geoenvironmental Engineering},
+  year    = {2020},
+  volume  = {146},
+  number  = {12},
+  pages   = {04020142},
+  doi     = {10.1061/(ASCE)GT.1943-5606.0002416}
+}
+
+@article{geyin2020field,
+  author  = {Geyin, Mertcan and Baird, Alex J. and Maurer, Brett W.},
+  title   = {Field assessment of liquefaction prediction models based on geotechnical versus geospatial data, with lessons for each},
+  journal = {Earthquake Spectra},
+  year    = {2020},
+  volume  = {36},
+  number  = {3},
+  pages   = {1386--1411},
+  doi     = {10.1177/8755293019899951}
+}
+
+@article{maurer2015,
+  author  = {Maurer, Brett W. and Green, Russell A. and Taylor, Oliver-Denzil S.},
+  title   = {Moving towards an improved index for assessing liquefaction hazard: Lessons from historical data},
+  journal = {Soils and Foundations},
+  year    = {2015},
+  volume  = {55},
+  number  = {4},
+  pages   = {778--787},
+  doi     = {10.1016/j.sandf.2015.06.010}
+}
+
+% --- Liquefaction-triggering fundamentals ---
+@article{seedidriss1971,
+  author  = {Seed, H. Bolton and Idriss, I. M.},
+  title   = {Simplified Procedure for Evaluating Soil Liquefaction Potential},
+  journal = {Journal of the Soil Mechanics and Foundations Division},
+  year    = {1971},
+  volume  = {97},
+  number  = {9},
+  pages   = {1249--1273},
+  doi     = {10.1061/JSFEAQ.0001662}
+}
+
+@article{idrissboulanger2006,
+  author  = {Idriss, I. M. and Boulanger, R. W.},
+  title   = {Semi-empirical procedures for evaluating liquefaction potential during earthquakes},
+  journal = {Soil Dynamics and Earthquake Engineering},
+  year    = {2006},
+  volume  = {26},
+  number  = {2-4},
+  pages   = {115--130},
+  doi     = {10.1016/j.soildyn.2004.11.023}
+}
+
+@book{idrissboulanger2008,
+  author    = {Idriss, I. M. and Boulanger, R. W.},
+  title     = {Soil Liquefaction During Earthquakes},
+  series    = {EERI Monograph MNO-12},
+  publisher = {Earthquake Engineering Research Institute},
+  address   = {Oakland, CA},
+  year      = {2008},
+  isbn      = {978-1-932884-36-4}
+}
+
+@article{andrusstokoe2000,
+  author  = {Andrus, Ronald D. and Stokoe, Kenneth H.},
+  title   = {Liquefaction Resistance of Soils from Shear-Wave Velocity},
+  journal = {Journal of Geotechnical and Geoenvironmental Engineering},
+  year    = {2000},
+  volume  = {126},
+  number  = {11},
+  pages   = {1015--1025},
+  doi     = {10.1061/(ASCE)1090-0241(2000)126:11(1015)}
+}
+
+@inproceedings{iwasaki1978,
+  author    = {Iwasaki, T. and Tatsuoka, F. and Tokida, K. and Yasuda, S.},
+  title     = {A Practical Method for Assessing Soil Liquefaction Potential Based on Case Studies at Various Sites in {Japan}},
+  booktitle = {Proc. 2nd Int. Conf. on Microzonation for Safer Construction},
+  year      = {1978},
+  volume    = {2},
+  pages     = {885--896},
+  address   = {San Francisco, CA},
+  note      = {Introduces the Liquefaction Potential Index (LPI); no DOI}
+}
+
+@article{vanballegooy2014,
+  author  = {van Ballegooy, S. and Malan, P. and Lacrosse, V. and Jacka, M. E. and Cubrinovski, M. and Bray, J. D. and O'Rourke, T. D. and Crawford, S. A. and Cowan, H.},
+  title   = {Assessment of Liquefaction-Induced Land Damage for Residential {Christchurch}},
+  journal = {Earthquake Spectra},
+  year    = {2014},
+  volume  = {30},
+  number  = {1},
+  pages   = {31--55},
+  doi     = {10.1193/031813EQS070M}
+}
+
+% --- Attenuation / kappa and the National Seismic Hazard Model ---
+@article{andersonhough1984,
+  author  = {Anderson, John G. and Hough, Susan E.},
+  title   = {A model for the shape of the {Fourier} amplitude spectrum of acceleration at high frequencies},
+  journal = {Bulletin of the Seismological Society of America},
+  year    = {1984},
+  volume  = {74},
+  number  = {5},
+  pages   = {1969--1993},
+  note    = {No registered DOI}
+}
+
+@article{ktenidou2015,
+  author  = {Ktenidou, Olga-Joan and Abrahamson, Norman A. and Drouet, St\'ephane and Cotton, Fabrice},
+  title   = {Understanding the physics of kappa: insights from a downhole array},
+  journal = {Geophysical Journal International},
+  year    = {2015},
+  volume  = {203},
+  number  = {1},
+  pages   = {678--691},
+  doi     = {10.1093/gji/ggv315}
+}
+
+@article{haendel2025,
+  author  = {H\"andel, Annabel and Pilz, Marco and Malatesta, Luca C. and Litwin, David and Cotton, Fabrice},
+  title   = {Detecting seasonal differences in high-frequency site response using kappa-zero},
+  journal = {Seismica},
+  year    = {2025},
+  volume  = {4},
+  number  = {1},
+  doi     = {10.26443/seismica.v4i1.1425}
+}
+
+@article{petersen2024,
+  author  = {Petersen, Mark D. and Shumway, Allison M. and Powers, Peter M. and Field, Edward H. and Moschetti, Morgan P. and Jaiswal, Kishor S. and others},
+  title   = {The 2023 {US} 50-State National Seismic Hazard Model: Overview and implications},
+  journal = {Earthquake Spectra},
+  year    = {2024},
+  volume  = {40},
+  number  = {1},
+  pages   = {5--88},
+  doi     = {10.1177/87552930231215428}
+}

--- a/myst.yml
+++ b/myst.yml
@@ -36,8 +36,10 @@ project:
         - file: book/chapters/datahub.md
         - file: book/chapters/datahub-integration-guide.md
         - file: book/chapters/datahub-landslide-inventory.md
+        - file: book/chapters/datahub-liquefaction-inventory.md
         - file: book/chapters/modelhub.md
         - file: book/chapters/modelhub-landslide.md
+        - file: book/chapters/modelhub-liquefaction.md
         - file: book/chapters/hazevalhub.md
         - file: book/chapters/gaia-translator.md
         - file: book/chapters/research-software.md


### PR DESCRIPTION
Builds out the **liquefaction track** of Pillar 2 (the Sanger/Maurer geospatial liquefaction model line), rebased onto current `main`.

## Pillar 2 §3 — liquefaction
- **GLM lineage** (Zhu/Baise → Sanger mechanics-informed surrogates) and **fundamental equations** (CSR/CRR/FS, LPI/LSN), with explicit statements of **where hydrology** (water table → effective stress) **and rigidity** (Vs → CRR + site amplification) enter.
- **Three framings** table — conditional (national) / unconditional (return period) / event-based — each with data + modeling needs.
- **Attenuation / κ₀** section: how κ₀ is measured, that it **varies seasonally** (Händel 2025, Ktenidou 2015), and the open question of feeding a time-varying site term into the fixed-κ₀ NSHM.
- **High-resolution GLM** argument (even static layers); the dynamic hydro + mechanical contribution.
- **Cross-hazard data inventory** with hazard-purpose **icons** (⛰️🔥🏚️🌊), cross-referenced to the landslide taxonomy.
- **Earth2Studio** integration for dynamic forcing + scenario ensembles.
- **Repo placeholders** (`gaia-model-liquefaction`, `gaia-vs-conus`) for Morgan to confirm — these 404 until created, intentionally.

## Roadmap
`DOCS_ROADMAP.md` §7 — liquefaction-track roadmap (3 products, data/model needs, the κ₀(t) research question, repos, L0–L4 phasing).

## References
17 new Crossref-verified entries (Zhu/Baise GLM, Seed-Idriss, Idriss-Boulanger, Andrus-Stokoe, Iwasaki LPI, van Ballegooy LSN, Geyin-Maurer, Anderson-Hough κ, Petersen NSHM, Ktenidou, Händel).

## Note on structure
`main` now has separate `modelhub-landslide` + `datahub-landslide-inventory` pages (a split-page pattern). This PR keeps liquefaction as **Pillar 2 §3** for now — happy to refactor it into parallel `modelhub-liquefaction` / `datahub-liquefaction-inventory` pages to match, if preferred (see PR discussion).

Builds clean (no broken citations/links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)