### PR TITLE
Point River Floods & Sediment Transport use case to seis-hydro-2-sed paper

### DIFF
--- a/book/chapters/hazard-floods.md
+++ b/book/chapters/hazard-floods.md
@@ -33,7 +33,7 @@ timing and magnitude, threshold-exceedance detection, lead time.)*
 
 ## Connection to use cases
 
-Relevant to the [2025 river floods & sediment transport](wa-2025-river-floods-sediment-transport).
+Relevant to the [2025 river floods & sediment transport](https://gaia-hazlab.github.io/seis-hydro-2-sed/).
 
 ## Open questions & roadmap
 

--- a/book/chapters/hazard-landslides.md
+++ b/book/chapters/hazard-landslides.md
@@ -131,7 +131,7 @@ catalog, and — for deep-seated — displacement-rate skill and early-warning l
 ## Connection to use cases
 
 Shallow failures feature in the
-[2025 Western Washington floods & landslides](wa-2025-river-floods-sediment-transport).
+[2025 Western Washington floods & landslides](https://gaia-hazlab.github.io/seis-hydro-2-sed/).
 
 ## Open questions & roadmap
 

--- a/book/chapters/problem-statement.md
+++ b/book/chapters/problem-statement.md
@@ -35,7 +35,7 @@ We ground our research in real-world coupled natural disasters that validate our
 :gutter: 3
 
 :::{grid-item-card} 2025 Western Washington Floods & Landslides
-:link: wa-2025-river-floods-sediment-transport
+:link: https://gaia-hazlab.github.io/seis-hydro-2-sed/
 Atmospheric river–driven flooding and landslides across western Washington, linking precipitation extremes, soil saturation history, and sediment transport from mountain to sea.
 :::
 

--- a/book/intro.md
+++ b/book/intro.md
@@ -19,7 +19,7 @@ title: GAIA HazLab
 	- [Research Software](chapters/research-software): Tools for reproducible, scalable workflows.
 - **Use Cases:**
 	- [WA-2001-2031 Nisqually Earthquake](chapters/wa-2001-2031-nisqually-earthquake)
-	- [WA-2025 River Floods & Sediment Transport](chapters/wa-2025-river-floods-sediment-transport)
+	- [WA-2025 River Floods & Sediment Transport](https://gaia-hazlab.github.io/seis-hydro-2-sed/)
 	- [WA-2025 Stehekin Post-fire Debris Flow](chapters/wa-2025-stehekin)
 	- [Convective Thunderstorms](chapters/convective-thunderstorms)
 - **System-Science Nexus:**

--- a/myst.yml
+++ b/myst.yml
@@ -45,7 +45,8 @@ project:
       children:
         - file: book/chapters/wa-2001-2031-nisqually-earthquake.md
         - file: book/chapters/wa-2025-stehekin.md
-        - file: book/chapters/wa-2025-river-floods-sediment-transport.md
+        - url: https://gaia-hazlab.github.io/seis-hydro-2-sed/
+          title: WA-2025 River Floods & Sediment Transport
         - file: book/chapters/convective-thunderstorms.md
     - file: book/chapters/project-organization.md
 


### PR DESCRIPTION
The 2025 river floods / sediment transport use case is a single paper hosted at <https://gaia-hazlab.github.io/seis-hydro-2-sed/>. This repoints everything that pointed at the in-book stub to that paper:

- **ToC nav entry** → external `url:` link (was a `file:` chapter)
- **In-text links** in `intro.md`, `problem-statement.md` (grid card), `hazard-landslides.md`, and `hazard-floods.md`

The `wa-2025-river-floods-sediment-transport.md` stub is **kept on disk** but no longer in the ToC, so it's easy to restore if you'd rather keep an in-book chapter. Build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)