### PR TITLE
Front page: hazard cards → book pages, Translator → GaiaAgent, and 'What we sense' cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,9 +364,9 @@
             <div class="section-head">
                 <div class="kicker">What we sense</div>
                 <h2>Listening to soil, slope, and sky</h2>
-                <p>Four coupled processes where dense sensing and physical models change what we can see.</p>
+                <p>Three coupled processes where dense sensing and physical models change what we can see.</p>
             </div>
-            <div class="grid grid-4">
+            <div class="grid grid-3">
                 <a class="feature" href="book/soil-memory/">
                     <div class="icon-badge">
                         <!-- soil / critical zone layers -->
@@ -377,7 +377,7 @@
                         </svg>
                     </div>
                     <h3>Soil memory</h3>
-                    <p>Seismic and DAS velocity turned into water-table depth and near-surface saturation — the soil's hydromechanical history.</p>
+                    <p>Exploring memory effects in the critical zone with soil reanalysis products and event catalogs — how antecedent wetting, drying, and disturbance set today's hazard.</p>
                     <span class="more">Explore →</span>
                 </a>
                 <a class="feature" href="book/hazard-landslides/">
@@ -405,19 +405,6 @@
                     </div>
                     <h3>Liquefaction</h3>
                     <p>How saturated soils lose strength under shaking — and how antecedent state modulates seismic ground failure.</p>
-                    <span class="more">Explore →</span>
-                </a>
-                <a class="feature" href="book/soil-memory/">
-                    <div class="icon-badge">
-                        <!-- evaporation / sun + vapor -->
-                        <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
-                            <circle cx="17" cy="7" r="3"/>
-                            <path d="M17 1.5V3M22.5 7H21M17 11v1.5M13 7h-1.5M20.5 3.5l-1 1M14.5 9.5l-1 1"/>
-                            <path d="M3 21c1-2 0-3 1.5-4.5M8 21c1-2 0-3 1.5-4.5M13 21c1-2 0-3 1.5-4.5"/>
-                        </svg>
-                    </div>
-                    <h3>Water through the critical zone</h3>
-                    <p>Infiltration, storage, and evapotranspiration moving water through soil — linking moisture to streams, groundwater, and the atmosphere.</p>
                     <span class="more">Explore →</span>
                 </a>
             </div>

--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
                     <p>Seismic and DAS velocity turned into water-table depth and near-surface saturation — the soil's hydromechanical history.</p>
                     <span class="more">Explore →</span>
                 </a>
-                <a class="feature" href="book/problem-statement/">
+                <a class="feature" href="book/hazard-landslides/">
                     <div class="icon-badge">
                         <!-- landslide / slope -->
                         <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
@@ -393,7 +393,7 @@
                     <p>Slope stability under atmospheric-river rainfall, coupling antecedent moisture and transient pore pressure.</p>
                     <span class="more">Explore →</span>
                 </a>
-                <a class="feature" href="book/problem-statement/">
+                <a class="feature" href="book/hazard-liquefaction-ground-failure/">
                     <div class="icon-badge">
                         <!-- liquefaction / ground + water -->
                         <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
@@ -469,15 +469,15 @@
                     <p>Benchmarks and skill scores to validate hazard forecasts against what actually happened.</p>
                     <span class="more">Evaluation tools →</span>
                 </a>
-                <a class="feature" href="book/gaia-translator/">
+                <a class="feature" href="book/gaia-agent/">
                     <div class="icon-badge">
                         <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M4 7h7M7.5 7v10M5 17h5"/>
                             <path d="M13 17l3.5-9 3.5 9M14.2 14h4.6"/>
                         </svg>
                     </div>
-                    <h3>GAIA Translator</h3>
-                    <p>Bridging vocabularies across atmosphere, hydrology, and solid-Earth communities.</p>
+                    <h3>GaiaAgent</h3>
+                    <p>The agentic-AI layer — a cross-disciplinary translator, agentic data downloaders, and research-software agents.</p>
                     <span class="more">Learn more →</span>
                 </a>
                 <a class="feature" href="book/research-software/">

--- a/website/index.html
+++ b/website/index.html
@@ -364,9 +364,9 @@
             <div class="section-head">
                 <div class="kicker">What we sense</div>
                 <h2>Listening to soil, slope, and sky</h2>
-                <p>Four coupled processes where dense sensing and physical models change what we can see.</p>
+                <p>Three coupled processes where dense sensing and physical models change what we can see.</p>
             </div>
-            <div class="grid grid-4">
+            <div class="grid grid-3">
                 <a class="feature" href="book/soil-memory/">
                     <div class="icon-badge">
                         <!-- soil / critical zone layers -->
@@ -377,7 +377,7 @@
                         </svg>
                     </div>
                     <h3>Soil memory</h3>
-                    <p>Seismic and DAS velocity turned into water-table depth and near-surface saturation — the soil's hydromechanical history.</p>
+                    <p>Exploring memory effects in the critical zone with soil reanalysis products and event catalogs — how antecedent wetting, drying, and disturbance set today's hazard.</p>
                     <span class="more">Explore →</span>
                 </a>
                 <a class="feature" href="book/hazard-landslides/">
@@ -405,19 +405,6 @@
                     </div>
                     <h3>Liquefaction</h3>
                     <p>How saturated soils lose strength under shaking — and how antecedent state modulates seismic ground failure.</p>
-                    <span class="more">Explore →</span>
-                </a>
-                <a class="feature" href="book/soil-memory/">
-                    <div class="icon-badge">
-                        <!-- evaporation / sun + vapor -->
-                        <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
-                            <circle cx="17" cy="7" r="3"/>
-                            <path d="M17 1.5V3M22.5 7H21M17 11v1.5M13 7h-1.5M20.5 3.5l-1 1M14.5 9.5l-1 1"/>
-                            <path d="M3 21c1-2 0-3 1.5-4.5M8 21c1-2 0-3 1.5-4.5M13 21c1-2 0-3 1.5-4.5"/>
-                        </svg>
-                    </div>
-                    <h3>Water through the critical zone</h3>
-                    <p>Infiltration, storage, and evapotranspiration moving water through soil — linking moisture to streams, groundwater, and the atmosphere.</p>
                     <span class="more">Explore →</span>
                 </a>
             </div>

--- a/website/index.html
+++ b/website/index.html
@@ -380,7 +380,7 @@
                     <p>Seismic and DAS velocity turned into water-table depth and near-surface saturation — the soil's hydromechanical history.</p>
                     <span class="more">Explore →</span>
                 </a>
-                <a class="feature" href="book/problem-statement/">
+                <a class="feature" href="book/hazard-landslides/">
                     <div class="icon-badge">
                         <!-- landslide / slope -->
                         <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
@@ -393,7 +393,7 @@
                     <p>Slope stability under atmospheric-river rainfall, coupling antecedent moisture and transient pore pressure.</p>
                     <span class="more">Explore →</span>
                 </a>
-                <a class="feature" href="book/problem-statement/">
+                <a class="feature" href="book/hazard-liquefaction-ground-failure/">
                     <div class="icon-badge">
                         <!-- liquefaction / ground + water -->
                         <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
@@ -469,15 +469,15 @@
                     <p>Benchmarks and skill scores to validate hazard forecasts against what actually happened.</p>
                     <span class="more">Evaluation tools →</span>
                 </a>
-                <a class="feature" href="book/gaia-translator/">
+                <a class="feature" href="book/gaia-agent/">
                     <div class="icon-badge">
                         <svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M4 7h7M7.5 7v10M5 17h5"/>
                             <path d="M13 17l3.5-9 3.5 9M14.2 14h4.6"/>
                         </svg>
                     </div>
-                    <h3>GAIA Translator</h3>
-                    <p>Bridging vocabularies across atmosphere, hydrology, and solid-Earth communities.</p>
+                    <h3>GaiaAgent</h3>
+                    <p>The agentic-AI layer — a cross-disciplinary translator, agentic data downloaders, and research-software agents.</p>
                     <span class="more">Learn more →</span>
                 </a>
                 <a class="feature" href="book/research-software/">


### PR DESCRIPTION
Landing-page (`index.html`, mirrored to the deployed `website/index.html`) updates. All changes are intentional; both files are kept byte-identical.

## Link changes
- **Landslides** card → `book/hazard-landslides/` (was `problem-statement`)
- **Liquefaction** card → `book/hazard-liquefaction-ground-failure/` (was `problem-statement`)
- **GAIA Translator** card → relinked to `book/gaia-agent/` and retitled **GaiaAgent** (the agentic-AI layer), matching the new DataHub / ModelHub / HazEvalHub / GaiaAgent nav.

## "What we sense" section cleanup (intentional copy/layout)
- **Removed** the fourth card, *Water through the critical zone*.
- **Rewrote** the *Soil memory* blurb to: exploring memory effects with **soil reanalysis products and event catalogs**.
- Adjusted the section for three cards: heading "Four coupled processes" → "Three", and grid `grid-4` → `grid-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)