### PR TITLE
Book intro: remove dark banner image so the title is visible

### DIFF
--- a/book/intro.md
+++ b/book/intro.md
@@ -2,9 +2,9 @@
 title: GAIA HazLab
 ---
 
-<div style="position: relative; width: 100%; min-height: 400px; background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.6)), url('img/img/banner.png') center/cover no-repeat; color: white; padding: 60px 20px; margin: -20px -20px 40px -20px; border-radius: 8px;">
-  <h1 style="font-size: 3em; margin-bottom: 20px; text-shadow: 2px 2px 4px rgba(0,0,0,0.7);">GAIA HazLab</h1>
-  <p style="font-size: 1.3em; max-width: 900px; text-shadow: 1px 1px 3px rgba(0,0,0,0.7);"><strong>A platform for system-science hazard assessment: integrating AI, data, and models to understand, predict, and mitigate climate-compounded geohazards.</strong></p>
+<div style="width: 100%; background: linear-gradient(135deg, #4b2e83 0%, #341f63 100%); color: white; padding: 56px 28px; margin: -20px -20px 40px -20px; border-radius: 8px;">
+  <h1 style="font-size: 3em; margin: 0 0 16px;">GAIA HazLab</h1>
+  <p style="font-size: 1.25em; max-width: 900px; margin: 0;"><strong>A platform for system-science hazard assessment: integrating AI, data, and models to understand, predict, and mitigate climate-compounded geohazards.</strong></p>
 </div>
 
 ---


### PR DESCRIPTION
The book landing hero ([`book/intro.md`](book/intro.md)) layered a dark `linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.6))` over `banner.png`, which washed out the white **GAIA HazLab** title.

This replaces the image + dark overlay with the clean **GAIA purple gradient** (`#4b2e83 → #341f63`, matching the book theme header and the dashboard sidebar) and drops the now-unneeded text-shadows. The title and tagline now read clearly.

`banner.png` is left in `book/img/` (now unused) — say the word and I’ll delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)