### PR TITLE
Front page: embed the GAIA knowledge graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,6 +521,29 @@
         </div>
     </section>
 
+    <!-- KNOWLEDGE GRAPH -->
+    <section class="dash" id="graph">
+        <div class="wrap">
+            <div>
+                <div class="kicker">How it all connects</div>
+                <h2>The GAIA knowledge graph</h2>
+                <p>
+                    Every hazard, the models that predict or detect it, and the data they rely on —
+                    one interactive view of the whole system. Hue is the category, brightness the
+                    subcategory; hover a node to trace its chain, click for detail.
+                </p>
+                <a href="book/graph/gaia-knowledge-graph.html" class="btn btn-primary">
+                    Open the full graph
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </a>
+            </div>
+            <div style="border-radius:14px;overflow:hidden;border:1px solid rgba(255,255,255,.12);background:#0e1320;min-height:440px">
+                <iframe src="book/graph/gaia-knowledge-graph.html" title="GAIA knowledge graph"
+                        loading="lazy" style="width:100%;height:440px;border:0;display:block"></iframe>
+            </div>
+        </div>
+    </section>
+
     <!-- PARTNERS -->
     <section class="partners" id="partners">
         <div class="wrap">

--- a/index.html
+++ b/index.html
@@ -539,7 +539,7 @@
             </div>
             <div style="border-radius:14px;overflow:hidden;border:1px solid rgba(255,255,255,.12);background:#0e1320;min-height:440px">
                 <iframe src="book/graph/gaia-knowledge-graph.html" title="GAIA knowledge graph"
-                        loading="lazy" style="width:100%;height:440px;border:0;display:block"></iframe>
+                        loading="lazy" sandbox="allow-scripts" style="width:100%;height:440px;border:0;display:block"></iframe>
             </div>
         </div>
     </section>

--- a/website/index.html
+++ b/website/index.html
@@ -521,6 +521,29 @@
         </div>
     </section>
 
+    <!-- KNOWLEDGE GRAPH -->
+    <section class="dash" id="graph">
+        <div class="wrap">
+            <div>
+                <div class="kicker">How it all connects</div>
+                <h2>The GAIA knowledge graph</h2>
+                <p>
+                    Every hazard, the models that predict or detect it, and the data they rely on —
+                    one interactive view of the whole system. Hue is the category, brightness the
+                    subcategory; hover a node to trace its chain, click for detail.
+                </p>
+                <a href="book/graph/gaia-knowledge-graph.html" class="btn btn-primary">
+                    Open the full graph
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </a>
+            </div>
+            <div style="border-radius:14px;overflow:hidden;border:1px solid rgba(255,255,255,.12);background:#0e1320;min-height:440px">
+                <iframe src="book/graph/gaia-knowledge-graph.html" title="GAIA knowledge graph"
+                        loading="lazy" style="width:100%;height:440px;border:0;display:block"></iframe>
+            </div>
+        </div>
+    </section>
+
     <!-- PARTNERS -->
     <section class="partners" id="partners">
         <div class="wrap">

--- a/website/index.html
+++ b/website/index.html
@@ -539,7 +539,7 @@
             </div>
             <div style="border-radius:14px;overflow:hidden;border:1px solid rgba(255,255,255,.12);background:#0e1320;min-height:440px">
                 <iframe src="book/graph/gaia-knowledge-graph.html" title="GAIA knowledge graph"
-                        loading="lazy" style="width:100%;height:440px;border:0;display:block"></iframe>
+                        loading="lazy" sandbox="allow-scripts" style="width:100%;height:440px;border:0;display:block"></iframe>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Follow-up to the merged knowledge-graph PR (#19): that PR added the graph artifact and made it deploy, but nothing surfaced it on the landing page.

This adds a **"How it all connects → The GAIA knowledge graph"** section to `index.html` (before Partners) that:
- **embeds the interactive graph** (iframe → `book/graph/gaia-knowledge-graph.html`), and
- has an **"Open the full graph"** button for the standalone view.

Root `index.html` and the deployed `website/index.html` are kept in sync. The graph file and the `website/book/graph` deploy copy are already on `main` from #19, so this just makes it visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)